### PR TITLE
Restructure mutability control + old changes yet to be pulled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ smooth_progress.egg-info/*
 *.xml
 *.iml
 test.py
+smooth_progress/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,0 @@
-# Default ignored files
-.idea/*
-build/*
-dist/*
-smooth_progress.egg-info/*
-*.xml
-*.iml
-test.py
-smooth_progress/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+**Documentation**
+
+- Added type hinting to the README code examples.
+
 ### 0.2.0
 
 **New**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In the near future, the plans are for `.close()` and `.open()` to be like pause 
 
 Here is a simple example to show how the bar is initialised and used:
 
-```
+```py
 import smooth_progress
 
 bar = smooth_progress.ProgressBar(limit=100)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A simple progress bar made primarily for my own personal use. Was made out of a 
 
 smooth-progress can be installed through pip. Either download the latest release from Codeberg/GitHub, or do `pip install smooth-progress` to install from PyPi. For the latest commits, check the `dev` branches on the repositories.
 
-smooth-progress was written in Python 3.9, but should work with Python 3.5 and up. A minimum of 3.5 is required due to the project's use of type hinting, which was introduced in that version.
+smooth-progress is currently developed in Python 3.11, but should work with Python 3.5 and up. A minimum of 3.5 is required due to the project's use of type hinting, which was introduced in that version.
 
 ## Usage
 
 Usage of smooth-progress is, as it should be, quite simple.
 
-The driving force of this module is the concept of "mutability", e.g., the openness of the progress bar to change. When the progress bar is mutable, or "open", it can be changed. When it is "closed" it cannot be changed, and will simply display its last state.
+The driving force of this library is the concept of "mutability", e.g., the openness of the progress bar to change. When the progress bar is mutable, or "open", it can be changed. When it is "closed" it cannot be changed, and will simply display its last state.
 
 The `ProgressBar` model has four basic functions provided for your use:
 
@@ -37,8 +37,7 @@ bar.close()
 
 Note that the bar is not automatically opened. This is to prevent accidental changes to it if it is initialised before it should be used. In the future, capabilities will be in place to make the above code a little more succinct.
 
-smooth_progress currently also defines one exception, `smooth_progress.exceptions.ProgressBarClosedException`, 
- which is thrown if you attempt to increment the ProgressBar when it is not open.
+smooth_progress currently also defines one exception, `smooth_progress.exceptions.ProgressBarClosedException`, which is thrown if you attempt to increment the ProgressBar when it is not open.
 
 ## Contributing
 

--- a/smooth_progress/exceptions.py
+++ b/smooth_progress/exceptions.py
@@ -2,12 +2,12 @@ class ProgressBarClosedError(Exception):
     """This exception indicates that a call has been made which requires the ProgressBar
     to be open, however the ProgressBar was closed at the time.
     """
-    def __eq__(self: object, other: object) -> bool:
+    def __eq__(self, other) -> bool:
         try:
             return self.call == other.call
         except AttributeError:
             return False
 
-    def __init__(self: object, call: str):
+    def __init__(self, call: str) -> None:
         self.call = call
         super().__init__(f"{self.call} was called, but ProgressBar is closed.")

--- a/smooth_progress/models.py
+++ b/smooth_progress/models.py
@@ -25,6 +25,20 @@ class ProgressBar:
         self.show_percent = show_percent
         self.state = None
 
+    def __update(self, completion: int, percentage: int) -> None:
+        """
+        Hidden method to update the state of the bar with new values. Should only be called from
+        within the class itself.
+
+        :param completion: the number of characters in the bar that are completed
+        :param percentage: the percentage of characters in the bar that are completed
+        """
+        self.state = (
+            f"[{'#' * completion}{'-' * (self.GRANULARITY - completion)}]"
+            + f"  {str(self.count)}/{str(self.limit)}"
+            + (f" [{percentage}%]" if self.show_percent else "")
+        )
+
     def close(self) -> bool:
         """
         Closes the ProgressBar from mutability, displaying its final state before interruption.
@@ -93,17 +107,3 @@ class ProgressBar:
         :param flush: whether to forcibly flush the stdout stream
         """
         print(self.state if display is None else display, end=end, flush=flush)
-
-    def __update(self, completion: int, percentage: int) -> None:
-        """
-        Hidden method to update the state of the bar with new values. Should only be called from
-        within the class itself.
-
-        :param completion: the number of characters in the bar that are completed
-        :param percentage: the percentage of characters in the bar that are completed
-        """
-        self.state = (
-            f"[{'#' * completion}{'-' * (self.GRANULARITY - completion)}]"
-            + f"  {str(self.count)}/{str(self.limit)}"
-            + (f" [{percentage}%]" if self.show_percent else "")
-        )

--- a/smooth_progress/models.py
+++ b/smooth_progress/models.py
@@ -41,13 +41,11 @@ class ProgressBar:
 
     def close(self) -> bool:
         """
-        Closes the ProgressBar from mutability, displaying its final state before interruption.
+        Closes the ProgressBar from mutability, displaying its state before closure.
 
-        Note that a carriage return is executed BEFORE the final display; this ensures console
-        outputs such as ^C from a Control+C SIGKILL will be overwritten.
+        :return: a status indicating whether the bar was previously open
         """
         if self.opened:
-            self.show(display = "\r" + self.state, end = "\n", flush = False)
             self.opened = False
             return True
         else:
@@ -69,31 +67,50 @@ class ProgressBar:
         else:
             raise ProgressBarClosedError(".increment()")
 
-    def interrupt(self) -> bool:
+    def interrupt(self, show_final = True) -> bool:
         """
-        A more forceful version of close(); interrupts the ProgressBar by closing it from
-        mutability, without displaying its final state.
+        Interrupts the ProgressBar by closing it from mutability and resets its progress.
+
+        :param show_final: optional; whether to show the final state of the bar before its
+                           interuption
+        :return: a status indicating whether the bar was previously open
         """
         if self.opened:
             self.opened = False
-            self.show(display="")
+
+            if show_final:
+                # carriage return ensures console outputs such as ^C from a Control+C SIGKILL
+                # are overwritten
+                self.show(display = "\r" + self.state, end = "\n", flush = False)
+            else:
+                self.show(display = "")
+
+            self.reset()
             return True
         else:
             return False
 
     def open(self) -> bool:
         """
-        Resets all progress and opens the ProgressBar to mutability, displaying its initial, empty
-        state.
+        Opens the ProgressBar to mutability.
+
+        :return: a status indicating whether the bar was previously closed
         """
         if self.opened:
             return False
         else:
-            self.count = 0
-            self.__update(0, 0)
-            self.show()
             self.opened = True
             return True
+
+    def reset(self, show = False) -> None:
+        """
+        Resets the progress of the ProgressBar.
+
+        :param show: optional; whether to display the initial empty bar
+        """
+        self.count = 0
+        self.__update(0, 0)
+        self.show()
 
     def show(self, display: str = None, end: str = "\r", flush: bool = True) -> None:
         """

--- a/smooth_progress/models.py
+++ b/smooth_progress/models.py
@@ -2,9 +2,10 @@ from math import floor
 from .exceptions import ProgressBarClosedError
 
 class ProgressBar:
-    """The primary class for the ProgressBar. All control operations exist as methods of
-    this class. Once the project is more completed, attributes will be hidden and
-    available through getter/setter method pairs.
+    """
+    The primary class for the ProgressBar. All control operations exist as methods of this class.
+    Once the project is more completed, attributes will be hidden and available through getter and
+    setter method pairs.
     """
     def __enter__(self):
         return self
@@ -14,8 +15,8 @@ class ProgressBar:
 
     def __init__(self, limit: int = 100, show_percent: bool = True) -> None:
         """
-        :param limit: int, optional, default 100.
-        :param show_percent: bool, optional, default True.
+        :param limit: optional; default 100
+        :param show_percent: optional; default True
         """
         self.count = None
         self.GRANULARITY = 50
@@ -25,73 +26,81 @@ class ProgressBar:
         self.state = None
 
     def close(self) -> bool:
-        """Closes the ProgressBar from mutability, displaying its final state before
-        interruption.
+        """
+        Closes the ProgressBar from mutability, displaying its final state before interruption.
 
-        Note that a carriage return is executed BEFORE the final display; this ensures
-        console outputs such as ^C from a Control+C SIGKILL will be overwritten.
+        Note that a carriage return is executed BEFORE the final display; this ensures console
+        outputs such as ^C from a Control+C SIGKILL will be overwritten.
         """
         if self.opened:
-            print("\r" + self.state)
+            self.show(display = "\r" + self.state, end = "\n", flush = False)
             self.opened = False
             return True
         else:
             return False
 
     def increment(self) -> None:
-        """Increments the progress and updates the display to reflect the new value. If
-        this incrementation takes the progress to the pre-defined limit, closes the
-        ProgressBar from mutability.
+        """
+        Increments the progress and updates the display to reflect the new value. If this
+        incrementation takes the progress to the pre-defined limit, closes the ProgressBar from
+        mutability.
         """
         if self.opened:
             self.count += 1
             fraction = self.count/self.limit
             self.__update(floor(fraction*self.GRANULARITY), floor(fraction*100))
-            print(self.state, end="\r", flush=True)
+            self.show()
             if self.count == self.limit:
                 self.close()
         else:
             raise ProgressBarClosedError(".increment()")
 
     def interrupt(self) -> bool:
-        """A more forceful version of close(); interrupts the ProgressBar by closing it
-        from mutability, without displaying its final state.
+        """
+        A more forceful version of close(); interrupts the ProgressBar by closing it from
+        mutability, without displaying its final state.
         """
         if self.opened:
             self.opened = False
-            print("", end="\r", flush=True)
+            self.show(display="")
             return True
         else:
             return False
 
     def open(self) -> bool:
-        """Resets all progress and opens the ProgressBar to mutability, displaying its
-        initial, empty state.
+        """
+        Resets all progress and opens the ProgressBar to mutability, displaying its initial, empty
+        state.
         """
         if self.opened:
             return False
         else:
             self.count = 0
-            self.state = f"[{'-'* self.GRANULARITY}]  0/{str(self.limit)}"
-            print(self.state, end="\r", flush=True)
+            self.__update(0, 0)
+            self.show()
             self.opened = True
             return True
 
-    def show(self, end: str = "\n") -> None:
-        """Display the current state of the bar, with the end character determined by
-        the call.
-
-        :param end: The end character, by default a new line. Only control characters
-                    are recommended, but any string can be passed.
+    def show(self, display: str = None, end: str = "\r", flush: bool = True) -> None:
         """
-        print(self.state, end=end, flush=True)
+        Display the current state of the bar, or some other defined content, with the end character
+        determined by the call.
+
+        :param display: the content to display, by default None, indicating that the current state
+                        of the bar should be displayed
+        :param end: the end character, by default a new line; only control characters are
+                    recommended, but any string can be passed
+        :param flush: whether to forcibly flush the stdout stream
+        """
+        print(self.state if display is None else display, end=end, flush=flush)
 
     def __update(self, completion: int, percentage: int) -> None:
-        """Hidden method to update the state of the bar with new values. Should only be
-        called from within the class itself.
+        """
+        Hidden method to update the state of the bar with new values. Should only be called from
+        within the class itself.
 
-        :param completion: int
-        :param percentage: int
+        :param completion: the number of characters in the bar that are completed
+        :param percentage: the percentage of characters in the bar that are completed
         """
         self.state = (
             f"[{'#' * completion}{'-' * (self.GRANULARITY - completion)}]"

--- a/smooth_progress/models.py
+++ b/smooth_progress/models.py
@@ -6,13 +6,13 @@ class ProgressBar:
     this class. Once the project is more completed, attributes will be hidden and
     available through getter/setter method pairs.
     """
-    def __enter__(self: object) -> object:
+    def __enter__(self):
         return self
 
-    def __exit__(self: object, t, val, tb) -> None:
+    def __exit__(self, t, val, tb) -> None:
         del self
 
-    def __init__(self: object, limit: int = 100, show_percent: bool = True) -> None:
+    def __init__(self, limit: int = 100, show_percent: bool = True) -> None:
         """
         :param limit: int, optional, default 100.
         :param show_percent: bool, optional, default True.
@@ -24,7 +24,7 @@ class ProgressBar:
         self.show_percent = show_percent
         self.state = None
 
-    def close(self: object) -> bool:
+    def close(self) -> bool:
         """Closes the ProgressBar from mutability, displaying its final state before
         interruption.
 
@@ -38,7 +38,7 @@ class ProgressBar:
         else:
             return False
 
-    def increment(self: object) -> None:
+    def increment(self) -> None:
         """Increments the progress and updates the display to reflect the new value. If
         this incrementation takes the progress to the pre-defined limit, closes the
         ProgressBar from mutability.
@@ -53,7 +53,7 @@ class ProgressBar:
         else:
             raise ProgressBarClosedError(".increment()")
 
-    def interrupt(self: object) -> bool:
+    def interrupt(self) -> bool:
         """A more forceful version of close(); interrupts the ProgressBar by closing it
         from mutability, without displaying its final state.
         """
@@ -64,7 +64,7 @@ class ProgressBar:
         else:
             return False
 
-    def open(self: object) -> bool:
+    def open(self) -> bool:
         """Resets all progress and opens the ProgressBar to mutability, displaying its
         initial, empty state.
         """
@@ -77,7 +77,7 @@ class ProgressBar:
             self.opened = True
             return True
 
-    def show(self: object, end: str = "\n") -> None:
+    def show(self, end: str = "\n") -> None:
         """Display the current state of the bar, with the end character determined by
         the call.
 
@@ -86,7 +86,7 @@ class ProgressBar:
         """
         print(self.state, end=end, flush=True)
 
-    def __update(self: object, completion: int, percentage: int) -> None:
+    def __update(self, completion: int, percentage: int) -> None:
         """Hidden method to update the state of the bar with new values. Should only be
         called from within the class itself.
 


### PR DESCRIPTION
- Added type hinting to the README code examples.
- Don't type hint self as object
- Use ProgressBar.show() internally
- README improvements and function order
- Restructure mutability control
